### PR TITLE
Fix off-by-1 buffer overflow in `HexToString`

### DIFF
--- a/tools/openocd-patch-for-ch347/ch347.patch
+++ b/tools/openocd-patch-for-ch347/ch347.patch
@@ -310,7 +310,7 @@ index 000000000..3c7ac2683
 +    char *str = calloc(size * 2 + 1, 1);
 +
 +    for (i = 0; i < size; i++)
-+        sprintf(str + 2 * i, "%02x ", buf[i]);
++        sprintf(str + 2 * i, "%02x", buf[i]);
 +    return str;
 +}
 +


### PR DESCRIPTION
Newer dev tools (gcc v13.2.0) add code that detects buffer overflows:

```
$ ./ch347prog-sram blinky_10.bit 
sram
Open On-Chip Debugger 0.12.0+dev-01192-g3a4f445bd-dirty (2024-10-05-19:08)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselecting 'jtag'
jtagspi_program
Info : clock speed 10000 kHz
*** buffer overflow detected ***: terminated
```

The buffer overflow needs to be fixed to be able to program the device through CH347.

Originally, during every iteration 4 characters are written to the output buffer = hex digits (2) + space (1) + `NUL` (1).
In subsequent iterations the past iteration space and `NUL`  are overwritten by the current iteration digits.
In the last iteration the `NUL` lands 1 character past the end of the buffer.

The fix removes the unused/overwritten space.